### PR TITLE
Save weights after each self-play game

### DIFF
--- a/web_chess_az.py
+++ b/web_chess_az.py
@@ -447,13 +447,14 @@ class Engine:
 
             log.info(f"[train] game {g} done in {time.time() - gt0:.2f}s")
 
+            # сохраняем веса после каждой self-play партии
+            try:
+                torch.save(self.net.state_dict(), WEIGHTS_FILE)
+                log.info(f"[train] saved weights after game {g} -> {WEIGHTS_FILE}")
+            except Exception as e:
+                log.error(f"[train] save after game {g} failed: {e}")
+
         dt = time.time() - t0
-        # сохраним веса
-        try:
-            torch.save(self.net.state_dict(), WEIGHTS_FILE)
-            log.info(f"[train] saved weights -> {WEIGHTS_FILE}")
-        except Exception as e:
-            log.error(f"[train] save failed: {e}")
 
         n = max(1, games)
         avg_loss = loss_sum / n


### PR DESCRIPTION
## Summary
- Persist network weights to disk after every self-play training game

## Testing
- `python -m py_compile web_chess_az.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd34d3a464832e834cf4723c619032